### PR TITLE
Switch from `therubyracer` to `mini_racer`

### DIFF
--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -3,7 +3,7 @@
 require "wappalyzer/version"
 
 require 'net/http'
-require 'v8'
+require 'mini_racer'
 require 'json'
 
 Encoding.default_external = Encoding::UTF_8
@@ -25,7 +25,7 @@ module Wappalyzer
         body = resp.body.encode('UTF-8', :invalid => :replace, :undef => :replace)
       end
 
-      cxt = V8::Context.new
+      cxt = MiniRacer::Context.new
       cxt.load File.join(@realdir, 'js', 'wappalyzer.js')
       cxt.load File.join(@realdir, 'js', 'driver.js')
       data = {'host' => uri.hostname, 'url' => url, 'html' => body, 'headers' => headers}

--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -19,8 +19,11 @@ module Wappalyzer
 
     def analyze(url)
       uri, body, headers = URI(url), nil, {}
-      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https', :open_timeout => 5) do |http|
-        resp = http.get(uri.request_uri)
+      Net::HTTP.start(uri.host, uri.port,
+                      :use_ssl => uri.scheme == 'https',
+                      :verify_mode => OpenSSL::SSL::VERIFY_NONE,
+                      :open_timeout => 5) do |http|
+        resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
         resp.each_header{|k,v| headers[k.downcase] = v}
         body = resp.body.encode('UTF-8', :invalid => :replace, :undef => :replace)
       end

--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -18,10 +18,6 @@ module Wappalyzer
       @categories, @apps = @json['categories'], @json['apps']
     end
 
-    def utf8_encoding(str)
-      str.encode('UTF-8', :invalid => :replace, :undef => :replace)
-    end
-
     def analyze(url)
       uri, body, headers = URI(url), nil, {}
       Net::HTTP.start(uri.host, uri.port,
@@ -34,7 +30,7 @@ module Wappalyzer
           resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
         end
 
-        resp.each_header { |k,v| headers[k.downcase] = utf8_encoding(v) }
+        resp.each_header { |k,v| headers[utf8_encoding(k).downcase] = utf8_encoding(v) }
         body = utf8_encoding(resp.body)
       end
 
@@ -44,6 +40,12 @@ module Wappalyzer
       data = {'host' => uri.hostname, 'url' => url, 'html' => body, 'headers' => headers}
       output = cxt.eval("w.apps = #{@apps.to_json}; w.categories = #{@categories.to_json}; w.driver.data = #{data.to_json}; w.driver.init();")
       JSON.load(output)
+    end
+
+    private
+
+    def utf8_encoding(str)
+      str.encode('UTF-8', :invalid => :replace, :undef => :replace)
     end
   end
 end

--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -5,6 +5,7 @@ require "wappalyzer/version"
 require 'net/http'
 require 'mini_racer'
 require 'json'
+require 'zlib'
 
 Encoding.default_external = Encoding::UTF_8
 
@@ -17,15 +18,24 @@ module Wappalyzer
       @categories, @apps = @json['categories'], @json['apps']
     end
 
+    def utf8_encoding(str)
+      str.encode('UTF-8', :invalid => :replace, :undef => :replace)
+    end
+
     def analyze(url)
       uri, body, headers = URI(url), nil, {}
       Net::HTTP.start(uri.host, uri.port,
                       :use_ssl => uri.scheme == 'https',
                       :verify_mode => OpenSSL::SSL::VERIFY_NONE,
                       :open_timeout => 5) do |http|
-        resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
-        resp.each_header{|k,v| headers[k.downcase] = v}
-        body = resp.body.encode('UTF-8', :invalid => :replace, :undef => :replace)
+        begin
+          resp = http.get(uri.request_uri)
+        rescue Zlib::DataError
+          resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
+        end
+
+        resp.each_header { |k,v| headers[k.downcase] = utf8_encoding(v) }
+        body = utf8_encoding(resp.body)
       end
 
       cxt = MiniRacer::Context.new

--- a/wappalyzer.gemspec
+++ b/wappalyzer.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", "~> 1.11"
   spec.add_dependency "rake", "~> 10.0"
   spec.add_dependency "rspec", "~> 3.0"
-  spec.add_dependency "therubyracer", "~> 0.12.2"
+  spec.add_dependency "mini_racer", "~> 0.1.4"
 end


### PR DESCRIPTION
When using this gem with Sidekiq we'd see the Sidekiq worker process die randomly. We came across [this issue](https://github.com/mperham/sidekiq/issues/2773) that pointed us in the right direction. Basically it looks like a thread-safety issue and it seems to have been resolved once we switched to `mini_racer`.
