### PR TITLE
Switched from therubyracer to mini_racer.

### DIFF
--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -3,7 +3,7 @@
 require "wappalyzer/version"
 
 require 'net/http'
-require 'v8'
+require 'mini_racer'
 require 'json'
 
 Encoding.default_external = Encoding::UTF_8
@@ -25,7 +25,7 @@ module Wappalyzer
         body = resp.body.encode('UTF-8', :invalid => :replace, :undef => :replace)
       end
 
-      cxt = V8::Context.new
+      cxt = MiniRacer::Context.new
       cxt.load File.join(@realdir, 'js', 'wappalyzer.js')
       cxt.load File.join(@realdir, 'js', 'driver.js')
       data = {'host' => uri.hostname, 'url' => url, 'html' => body, 'headers' => headers}

--- a/wappalyzer.gemspec
+++ b/wappalyzer.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", "~> 1.11"
   spec.add_dependency "rake", "~> 10.0"
   spec.add_dependency "rspec", "~> 3.0"
-  spec.add_dependency "therubyracer", "~> 0.12.2"
+  spec.add_dependency "mini_racer", "~> 0.1.4"
 end


### PR DESCRIPTION
When using this gem with Sidekiq we'd see the Sidekiq worker process die randomly. We came across [this issue](https://github.com/mperham/sidekiq/issues/2773) that pointed us in the right direction. Basically it looks like a thread-safety issue and it seems to have been resolved once we switched to `mini_racer`.
