### PR TITLE
Fixing a few fringe errors.

### DIFF
--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -19,8 +19,11 @@ module Wappalyzer
 
     def analyze(url)
       uri, body, headers = URI(url), nil, {}
-      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https', :open_timeout => 5) do |http|
-        resp = http.get(uri.request_uri)
+      Net::HTTP.start(uri.host, uri.port,
+                      :use_ssl => uri.scheme == 'https',
+                      :verify_mode => OpenSSL::SSL::VERIFY_NONE,
+                      :open_timeout => 5) do |http|
+        resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
         resp.each_header{|k,v| headers[k.downcase] = v}
         body = resp.body.encode('UTF-8', :invalid => :replace, :undef => :replace)
       end

--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -18,10 +18,6 @@ module Wappalyzer
       @categories, @apps = @json['categories'], @json['apps']
     end
 
-    def utf8_encoding(str)
-      str.encode('UTF-8', :invalid => :replace, :undef => :replace)
-    end
-
     def analyze(url)
       uri, body, headers = URI(url), nil, {}
       Net::HTTP.start(uri.host, uri.port,
@@ -34,7 +30,7 @@ module Wappalyzer
           resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
         end
 
-        resp.each_header { |k,v| headers[k.downcase] = utf8_encoding(v) }
+        resp.each_header { |k,v| headers[utf8_encoding(k).downcase] = utf8_encoding(v) }
         body = utf8_encoding(resp.body)
       end
 
@@ -44,6 +40,12 @@ module Wappalyzer
       data = {'host' => uri.hostname, 'url' => url, 'html' => body, 'headers' => headers}
       output = cxt.eval("w.apps = #{@apps.to_json}; w.categories = #{@categories.to_json}; w.driver.data = #{data.to_json}; w.driver.init();")
       JSON.load(output)
+    end
+
+    private
+
+    def utf8_encoding(str)
+      str.encode('UTF-8', :invalid => :replace, :undef => :replace)
     end
   end
 end

--- a/lib/wappalyzer.rb
+++ b/lib/wappalyzer.rb
@@ -5,6 +5,7 @@ require "wappalyzer/version"
 require 'net/http'
 require 'mini_racer'
 require 'json'
+require 'zlib'
 
 Encoding.default_external = Encoding::UTF_8
 
@@ -17,15 +18,24 @@ module Wappalyzer
       @categories, @apps = @json['categories'], @json['apps']
     end
 
+    def utf8_encoding(str)
+      str.encode('UTF-8', :invalid => :replace, :undef => :replace)
+    end
+
     def analyze(url)
       uri, body, headers = URI(url), nil, {}
       Net::HTTP.start(uri.host, uri.port,
                       :use_ssl => uri.scheme == 'https',
                       :verify_mode => OpenSSL::SSL::VERIFY_NONE,
                       :open_timeout => 5) do |http|
-        resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
-        resp.each_header{|k,v| headers[k.downcase] = v}
-        body = resp.body.encode('UTF-8', :invalid => :replace, :undef => :replace)
+        begin
+          resp = http.get(uri.request_uri)
+        rescue Zlib::DataError
+          resp = http.get(uri.request_uri, "Accept-Encoding" => "none")
+        end
+
+        resp.each_header { |k,v| headers[k.downcase] = utf8_encoding(v) }
+        body = utf8_encoding(resp.body)
       end
 
       cxt = MiniRacer::Context.new


### PR DESCRIPTION
We noticed a few errors when running the wappalyzer on unusual websites.

One was a `Zlib::DataError`, which seemed to be a ruby issue in the handling of certain types of compression. If this error occurs, we catch it and instead run the http.get request with an additional `"Accept-Encoding" => "none"` parameter. This was recommended as a fix for this error [here](https://github.com/lostisland/faraday/issues/120), and has worked so far for us.

Next was an `OpenSSL::SSL::SSLError`, which occurs when we don't have the proper certificates for a website. We added `:verify_mode => OpenSSL::SSL::VERIFY_NONE` to address this, as the information being retrieved is publicly accessible anyway.

Lastly, we saw an `Encoding::UndefinedConversionError: "\xE2" from ASCII-8BIT to UTF-8` error. This seemed to occur because certain header values contained characters that weren't valid in UTF-8. An example of this can be found when running the wappalyzer on [this](http://www.mariefrancecarriere.ca/) most interesting website. Encoding the header values (and keys to be safe) in the same manner as the body string fixes this issue.