### PR TITLE
Make bundler, rake, and rspec development dependencies

### DIFF
--- a/wappalyzer.gemspec
+++ b/wappalyzer.gemspec
@@ -13,15 +13,14 @@ Gem::Specification.new do |spec|
   spec.description   = %q{This analyzes a url and tries to guess what software it uses (like server software, CMS, framework, programming language).}
   spec.homepage      = "https://github.com/pulkit21/wappalyzer"
 
-
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bundler", "~> 1.11"
-  spec.add_dependency "rake", "~> 10.0"
-  spec.add_dependency "rspec", "~> 3.0"
   spec.add_dependency "mini_racer", "~> 0.1.4"
+
+  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
@pulkit21 Hey, thanks for the gem!

This PR will prevent these dependencies from being included in bundles of apps that include this gem. For example, non-`rspec` apps shouldn't need `rspec` installed just for this gem.

This is what happens on our app's `Gemfile.lock` after updating this gem to 5f08cd8: 
```diff
   specs:
     wappalyzer (0.1.0)
-      bundler (~> 1.11)
       mini_racer (~> 0.1.4)
-      rake (~> 10.0)
-      rspec (~> 3.0)
…
-    diff-lcs (1.2.5)
…
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
```

This appears to be more inline with what other gems do. http://bundler.io/rubygems.html